### PR TITLE
Add "Prefix" option to getObjectVersions method

### DIFF
--- a/src/S3ToolsAdapter.php
+++ b/src/S3ToolsAdapter.php
@@ -63,6 +63,7 @@ class S3ToolsAdapter extends \League\Flysystem\AwsS3v3\AwsS3Adapter // AbstractA
 			$options = [
 				'Bucket' => $this->bucket,
 				'Key'    => $this->applyPathPrefix($path),
+				'Prefix' => $path,
 			];
 
 			//if (isset($versionId))
@@ -89,7 +90,7 @@ class S3ToolsAdapter extends \League\Flysystem\AwsS3v3\AwsS3Adapter // AbstractA
       	if( count($versionList))
       	{
         	$versions = [];
-	
+
         	foreach($response['Versions'] as $r)
           	$versions[] = [
             	'versionId' => $r['VersionId'],
@@ -97,7 +98,7 @@ class S3ToolsAdapter extends \League\Flysystem\AwsS3v3\AwsS3Adapter // AbstractA
             	'isLatest' => $r['IsLatest'],
             	'dateModified' => $r['LastModified']
           	];
-	
+
         	return $versions;
       	}
 			}
@@ -255,7 +256,7 @@ class S3ToolsAdapter extends \League\Flysystem\AwsS3v3\AwsS3Adapter // AbstractA
 			$result = $this->s3Client->execute($command);
 
 			if($result) return $result;
-	
+
 			return null;
 		}
 }


### PR DESCRIPTION
Thanks for sending a pull request! Please provide the following information:

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds `Prefix` option to `getObjectVersions` method so that versions are only returning for the specific object.

Does this close any currently open issues?
------------------------------------------
Resolves https://github.com/sburkett/laravel-s3-tools/issues/5

Any relevant logs, error output, etc?
-------------------------------------
n/a

Any other comments?
-------------------
n/a

