### PR TITLE
Add option to pass 'disable_asserts' config option through to the S3T…

### DIFF
--- a/src/S3ToolsServiceProvider.php
+++ b/src/S3ToolsServiceProvider.php
@@ -50,7 +50,7 @@ class S3ToolsServiceProvider extends ServiceProvider
 
 			$adapter = new S3ToolsAdapter($client, $s3Config['bucket']);
 
-			$filesystem = new S3ToolsFilesystem($adapter);
+			$filesystem = new S3ToolsFilesystem($adapter, ['disable_asserts' => (bool) $config['disable_asserts']]);
 			$filesystem->diskName = $this->diskName;
 
 			return $filesystem;


### PR DESCRIPTION
…oolsFilesystem class. This allows the ability to define the 'disable_asserts' for this specific disk within the config/filesystems.php file.

Thanks for sending a pull request! Please provide the following information:

What does this implement/fix? Explain your changes.
---------------------------------------------------
I have an instance within a project where I loop over a number of file paths and call getObjectVersions() to get a list of all versions for that file path in S3. I then attempt to delete the file on s3 by calling Storage::disk('s3-tools')->getVersion('ID_HERE')->delete(). 

This always works for the first file iteration but any subsequent iteration returns a file not found error, even though I can see the file in my s3 bucket.

I've managed to track this down to $this->assertPresent($path) which is called within the getObjectVersions() method in the S3ToolsFileystem.php file. Commenting out the $this->assertPresent() fixes my issue, so I was just looking for a nice way to disable the asserts on this specific disk by adding it into the filesystem config.

Does this close any currently open issues?
------------------------------------------
N/A

Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------
N/A

